### PR TITLE
Update launcher.py fix no module named Queue python v3 fix

### DIFF
--- a/tools/sofa-launcher/launcher.py
+++ b/tools/sofa-launcher/launcher.py
@@ -9,7 +9,7 @@
 #       - damien.marchal@univ-lille.1
 #############################################################################
 import threading
-from queue import Queue
+from multiprocessing import Queue
 import tempfile 
 import sys
 from Cheetah.Template import Template


### PR DESCRIPTION
Update launcher.py fix no module named Queue python v3 fix






______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
